### PR TITLE
Fix: Create missing /api/packages endpoint

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -30,6 +30,14 @@ global.Response = class Response {
       }
     });
   }
+
+  async json() {
+    return JSON.parse(this.body);
+  }
+
+  async text() {
+    return this.body;
+  }
 };
 
 // Mock Privy authentication

--- a/src/app/api/packages/__tests__/route.test.ts
+++ b/src/app/api/packages/__tests__/route.test.ts
@@ -1,0 +1,25 @@
+import { GET } from '../route';
+import { PACKAGES } from '@/lib/constants';
+
+describe('GET /api/packages', () => {
+  it('should return packages with prices in reais', async () => {
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data).toHaveLength(Object.values(PACKAGES).length);
+
+    // Check first package
+    const firstPackage = data.data[0];
+    const originalPackage = Object.values(PACKAGES).find(p => p.id === firstPackage.id);
+
+    expect(originalPackage).toBeDefined();
+    if (originalPackage) {
+      expect(firstPackage.price).toBe(originalPackage.price / 100);
+      if (originalPackage.originalPrice) {
+        expect(firstPackage.originalPrice).toBe(originalPackage.originalPrice / 100);
+      }
+    }
+  });
+});

--- a/src/app/api/packages/route.ts
+++ b/src/app/api/packages/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { PACKAGES } from '@/lib/constants';
+
+export async function GET() {
+  try {
+    const packages = Object.values(PACKAGES).map(pkg => ({
+      ...pkg,
+      price: pkg.price / 100, // Convert cents to reais
+      originalPrice: pkg.originalPrice ? pkg.originalPrice / 100 : undefined,
+    }));
+
+    return NextResponse.json({
+      success: true,
+      data: packages
+    });
+  } catch (error) {
+    console.error('Error serving packages:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch packages' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Fixed the issue where packages were not loading on the frontend by creating the missing `/api/packages` endpoint.
The endpoint returns the package data defined in `src/lib/constants.ts`.
Verified with unit tests and a frontend verification script.

---
*PR created automatically by Jules for task [9465313580248285765](https://jules.google.com/task/9465313580248285765) started by @govinda777*