### PR TITLE
fix: Resolve unused variable warnings in build

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,14 @@
 {
   "extends": ["next/core-web-vitals", "prettier"],
+  "plugins": ["@typescript-eslint"],
   "rules": {
     "prefer-const": "error",
-    "no-unused-vars": "warn",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": ["warn", {
+      "argsIgnorePattern": "^_",
+      "varsIgnorePattern": "^_",
+      "caughtErrorsIgnorePattern": "^_"
+    }],
     "react/no-unescaped-entities": "warn"
   },
   "ignorePatterns": ["node_modules/", ".next/", "out/", "build/", "*.config.js", "*.setup.js"]

--- a/src/components/checkout/CheckoutFormNew.tsx
+++ b/src/components/checkout/CheckoutFormNew.tsx
@@ -305,7 +305,7 @@ export function CheckoutForm({ cartItems, onBack, onSuccess }: CheckoutFormProps
     setIsSubmitting(true);
 
     try {
-      const result = await createAndProcessOrder(lastOrderData);
+      await createAndProcessOrder(lastOrderData);
 
       // Payment initiated successfully
       setPaymentStatus('success');

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { cn, openWhatsApp } from '@/lib/utils';
-import { NAVIGATION_ITEMS, NAVIGATION_GROUPS, CONTACT_INFO } from '@/lib/constants';
+import { NAVIGATION_ITEMS, CONTACT_INFO } from '@/lib/constants';
 import { LoginButton } from '@/components/auth';
 
 export function Navigation() {

--- a/src/core/services/IPaymentService.ts
+++ b/src/core/services/IPaymentService.ts
@@ -1,4 +1,3 @@
-import { Order } from '../entities/Order';
 import { PaymentMethod } from '../entities/Coupon';
 
 export interface CreatePreferenceRequest {

--- a/src/core/use-cases/packages/GetPackageAvailability.ts
+++ b/src/core/use-cases/packages/GetPackageAvailability.ts
@@ -99,7 +99,7 @@ export class GetPackageAvailability {
     return Math.max(0, maxSpots - bookedSpots);
   }
 
-  private getWeatherConditions(date: Date): 'good' | 'warning' | 'poor' {
+  private getWeatherConditions(_date: Date): 'good' | 'warning' | 'poor' {
     // Mock weather API - in real app would call weather service
     const conditions: ('good' | 'warning' | 'poor')[] = ['good', 'good', 'warning', 'poor'];
     return conditions[Math.floor(Math.random() * conditions.length)];

--- a/src/tests/bdd/steps/authentication.steps.ts
+++ b/src/tests/bdd/steps/authentication.steps.ts
@@ -4,7 +4,6 @@ import { expect } from '@jest/globals';
 import '@testing-library/jest-dom';
 import { CustomWorld } from '../support/world';
 import { LoginButton } from '@/components/auth/LoginButton';
-import { AuthGuard } from '@/components/auth/AuthGuard';
 import React from 'react';
 
 // Mock the useAuth hook for testing

--- a/src/tests/bdd/steps/checkout-process.steps.ts
+++ b/src/tests/bdd/steps/checkout-process.steps.ts
@@ -1,5 +1,4 @@
 import { Given, When, Then } from '@cucumber/cucumber';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { expect } from '@jest/globals';
 import { CustomWorld } from '../support/world';
 import { CheckoutForm } from '@/components/cart/CheckoutForm';

--- a/src/tests/bdd/steps/complete-booking-journey.steps.ts
+++ b/src/tests/bdd/steps/complete-booking-journey.steps.ts
@@ -1,5 +1,4 @@
 import { Given, When, Then } from '@cucumber/cucumber';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { expect } from '@jest/globals';
 import { CustomWorld } from '../support/world';
 
@@ -24,12 +23,6 @@ const mockBookingService = {
   updateBooking: jest.fn(),
   cancelBooking: jest.fn(),
   getBooking: jest.fn(),
-};
-
-const mockPaymentService = {
-  createPixPayment: jest.fn(),
-  createCryptoPayment: jest.fn(),
-  processPayment: jest.fn(),
 };
 
 // Background steps

--- a/src/tests/bdd/steps/package-browsing.steps.ts
+++ b/src/tests/bdd/steps/package-browsing.steps.ts
@@ -1,5 +1,4 @@
 import { Given, When, Then } from '@cucumber/cucumber';
-import { screen, waitFor } from '@testing-library/react';
 import { expect } from '@jest/globals';
 import { CustomWorld } from '../support/world';
 import { PackagesSection } from '@/components/sections/PackagesSection';

--- a/src/tests/bdd/steps/shopping-cart.steps.ts
+++ b/src/tests/bdd/steps/shopping-cart.steps.ts
@@ -1,5 +1,5 @@
 import { Given, When, Then } from '@cucumber/cucumber';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import { expect } from '@jest/globals';
 import { CustomWorld } from '../support/world';
 import { CartButton } from '@/components/cart/CartButton';

--- a/src/themes/ThemeProvider.tsx
+++ b/src/themes/ThemeProvider.tsx
@@ -20,10 +20,6 @@ const staticThemes = {
   [THEME_IDS.PEDRA_BELA]: pedraBellaTheme,
 };
 
-const isValidThemeId = (themeId: string): themeId is keyof typeof staticThemes => {
-  return themeId in staticThemes;
-};
-
 console.log('ThemeProvider: Available static themes:', Object.keys(staticThemes));
 
 interface ThemeContextType {
@@ -52,7 +48,6 @@ function ThemeProviderContent({ children }: { children: React.ReactNode }) {
 
     try {
       const dynamicThemes: ThemeConfig[] = [];
-      const activeThemeIds = new Set(tours.map(t => t.themeId));
       
       for (const tour of tours) {
         try {


### PR DESCRIPTION
This PR resolves the numerous "defined but never used" warnings in the build process.

Changes:
1. Updated `.eslintrc.json` to disable the base `no-unused-vars` rule and enable `@typescript-eslint/no-unused-vars`. This properly handles TypeScript interfaces and function types, and allows ignoring variables prefixed with `_`.
2. Removed unused imports and variables in:
   - `src/components/checkout/CheckoutFormNew.tsx`
   - `src/components/layout/Navigation.tsx`
   - `src/core/services/IPaymentService.ts`
   - `src/tests/bdd/steps/*.ts`
   - `src/themes/ThemeProvider.tsx`
3. Renamed unused argument in `GetPackageAvailability.ts` to `_date` to comply with the new linting rule.

Verification:
- `npm run lint` passes with 0 warnings.
- `npm run build` succeeds.

---
*PR created automatically by Jules for task [3573617566252967683](https://jules.google.com/task/3573617566252967683) started by @govinda777*