### PR TITLE
Fix order creation failing when Mercado Pago is not configured

### DIFF
--- a/src/core/repositories/IOrderRepository.ts
+++ b/src/core/repositories/IOrderRepository.ts
@@ -3,6 +3,7 @@ import { Order } from '../entities/Order';
 export interface IOrderRepository {
   create(_order: Order): Promise<string>; // Creates Mercado Pago preference, returns preference ID
   createWhatsAppOrder(_order: Order): Promise<string>; // Returns order ID for WhatsApp
+  save(_order: Order): Promise<void>; // Save order without MP preference
   findById(_preferenceId: string): Promise<Order | null>; // From MP metadata
   findByUserId(_userId: string): Promise<Order[]>; // From MP search
   update(_order: Order): Promise<void>; // Update order

--- a/src/infrastructure/repositories/OrderRepository.ts
+++ b/src/infrastructure/repositories/OrderRepository.ts
@@ -74,6 +74,15 @@ export class OrderRepository implements IOrderRepository {
     }
   }
 
+  async save(order: Order): Promise<void> {
+    try {
+      this.storeOrderLocally(order, order.id);
+    } catch (error) {
+      console.error('Error saving order:', error);
+      throw new Error('Failed to save order');
+    }
+  }
+
   async findById(preferenceId: string): Promise<Order | null> {
     try {
       // First try to get from local storage


### PR DESCRIPTION
Refactored `CreateOrder` use case to avoid unconditionally creating a Mercado Pago preference for all orders. This prevents errors when Mercado Pago credentials are missing but the user selects another payment method (e.g., WhatsApp).

Previously, `OrderRepository.create` was called for every order, which triggered `PaymentService.createPreference` and threw an error if MP credentials were missing.

Now, `CreateOrder` delegates persistence to the appropriate repository method based on the selected payment method:
- Mercado Pago: `create` (creates preference)
- WhatsApp: `createWhatsAppOrder` (persists and logs for WhatsApp)
- Others (PIX, Crypto): `save` (new method for local persistence only)

Also updated integration tests to reflect the new flow and fixed issues with mocks.

---
*PR created automatically by Jules for task [5741443252677372717](https://jules.google.com/task/5741443252677372717) started by @govinda777*