### PR TITLE
Reorder experience level options and fix usePackages tests

### DIFF
--- a/src/components/cart/CheckoutForm.tsx
+++ b/src/components/cart/CheckoutForm.tsx
@@ -347,10 +347,10 @@ function ParticipantDetailsStep({ cartItems, participantDetails, onChange }: any
                 onChange={e => onChange(item.id, 'experienceLevel', e.target.value)}
               >
                 <option value="">Selecione</option>
+                <option value="minha_primeira_vez">Minha primeira vez</option>
                 <option value="beginner">Iniciante</option>
                 <option value="intermediate">Intermediário</option>
                 <option value="advanced">Avançado</option>
-                <option value="minha_primeira_vez">Minha primeira vez</option>
               </select>
             </div>
 

--- a/src/components/checkout/CheckoutFormNew.tsx
+++ b/src/components/checkout/CheckoutFormNew.tsx
@@ -624,10 +624,10 @@ function ParticipantDetailsStep({ cartItems, participantDetails, onChange }: any
                 onChange={e => onChange(item.id, 'experienceLevel', e.target.value)}
               >
                 <option value="">Selecione</option>
+                <option value="minha_primeira_vez">Minha primeira vez</option>
                 <option value="beginner">Iniciante</option>
                 <option value="intermediate">Intermediário</option>
                 <option value="advanced">Avançado</option>
-                <option value="minha_primeira_vez">Minha primeira vez</option>
               </select>
             </div>
 

--- a/src/hooks/__tests__/usePackages.test.ts
+++ b/src/hooks/__tests__/usePackages.test.ts
@@ -38,17 +38,21 @@ const mockPackages: Package[] = [
 ];
 
 // Mock the use cases first
-jest.mock('@/core/use-cases/packages/GetAllPackages', () => ({
-  GetAllPackages: jest.fn().mockImplementation(() => ({
-    execute: jest.fn(),
-  })),
-}));
+jest.mock('@/core/use-cases/packages/GetAllPackages', () => {
+  const execute = jest.fn();
+  const GetAllPackages = jest.fn().mockImplementation(() => ({ execute }));
+  // @ts-ignore
+  GetAllPackages.mockExecute = execute;
+  return { GetAllPackages };
+});
 
-jest.mock('@/core/use-cases/packages/GetPackageAvailability', () => ({
-  GetPackageAvailability: jest.fn().mockImplementation(() => ({
-    execute: jest.fn(),
-  })),
-}));
+jest.mock('@/core/use-cases/packages/GetPackageAvailability', () => {
+  const execute = jest.fn();
+  const GetPackageAvailability = jest.fn().mockImplementation(() => ({ execute }));
+  // @ts-ignore
+  GetPackageAvailability.mockExecute = execute;
+  return { GetPackageAvailability };
+});
 
 // Mock the repository
 jest.mock('@/infrastructure/repositories/PackageRepository', () => ({
@@ -66,9 +70,14 @@ describe('usePackages Hook', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     
-    // Create new instances and get their mocks
-    mockGetAllPackages = new GetAllPackages();
-    mockGetPackageAvailability = new GetPackageAvailability();
+    // Get the shared mocks
+    // @ts-ignore
+    const getAllPackagesExecute = GetAllPackages.mockExecute;
+    // @ts-ignore
+    const getPackageAvailabilityExecute = GetPackageAvailability.mockExecute;
+
+    mockGetAllPackages = { execute: getAllPackagesExecute };
+    mockGetPackageAvailability = { execute: getPackageAvailabilityExecute };
     
     mockGetAllPackages.execute.mockResolvedValue(mockPackages);
     mockGetPackageAvailability.execute.mockResolvedValue({


### PR DESCRIPTION
This change updates the order of options in the experience level dropdown within the checkout forms. "Minha primeira vez" is now the first option available after the default "Selecione" placeholder, as requested.

Additionally, this PR includes a fix for `src/hooks/__tests__/usePackages.test.ts` where tests were failing due to incorrect mocking of singleton use cases. The tests now use a shared mock function to ensure assertions are made against the correct instance.

---
*PR created automatically by Jules for task [279337761864717192](https://jules.google.com/task/279337761864717192) started by @govinda777*