### PR TITLE
feat: Add input mask and validation for WhatsApp in CheckoutForm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "next": "15.0.7",
         "react": "^18",
         "react-dom": "^18",
+        "react-input-mask": "^2.0.4",
         "tailwind-merge": "^3.3.1",
         "viem": "^2.21.19",
         "zustand": "^5.0.1"
@@ -28,6 +29,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/react-input-mask": "^3.0.6",
         "autoprefixer": "^10.4.20",
         "eslint": "^8",
         "eslint-config-next": "15.0.3",
@@ -7115,6 +7117,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-input-mask": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-input-mask/-/react-input-mask-3.0.6.tgz",
+      "integrity": "sha512-+5I18WKyG3eWIj7TVPWfK1VitI9mPpS9y6jE/BfmTCe+iL27NfBw/yzKRvCFp1DRBvlvvcsiZf05bub0YC1k8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -14763,6 +14775,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -21348,6 +21369,20 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-input-mask": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
+      "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0",
+        "react-dom": ">=0.14.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -23923,6 +23958,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/web-vitals": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "next": "15.0.7",
     "react": "^18",
     "react-dom": "^18",
+    "react-input-mask": "^2.0.4",
     "tailwind-merge": "^3.3.1",
     "viem": "^2.21.19",
     "zustand": "^5.0.1"
@@ -46,6 +47,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/react-input-mask": "^3.0.6",
     "autoprefixer": "^10.4.20",
     "eslint": "^8",
     "eslint-config-next": "15.0.3",

--- a/src/components/cart/CheckoutForm.tsx
+++ b/src/components/cart/CheckoutForm.tsx
@@ -10,6 +10,7 @@ import { OrderRepository } from '@/infrastructure/repositories/OrderRepository';
 import { CartItem } from '@/types';
 import { ParticipantDetails, ClimbingDetails } from '@/core/entities/Order';
 import { AVAILABLE_DATES } from '@/lib/constants';
+import InputMask from 'react-input-mask';
 
 interface CheckoutFormProps {
   cartItems: CartItem[];
@@ -71,12 +72,16 @@ export function CheckoutForm({ cartItems, onBack, onSuccess }: CheckoutFormProps
       case 0: // Participant details
         return cartItems.every(item => {
           const details = formData.participantDetails[item.id];
+          if (!details) return false;
+
+          const isWhatsappValid = details.whatsapp ? details.whatsapp.replace(/\D/g, '').length === 11 : false;
+
           return (
-            details &&
             details.name &&
             details.age &&
             details.experienceLevel &&
-            details.healthDeclaration
+            details.healthDeclaration &&
+            isWhatsappValid
           );
         });
       case 1: // Climbing details
@@ -356,14 +361,15 @@ function ParticipantDetailsStep({ cartItems, participantDetails, onChange }: any
               htmlFor={`whatsapp-${item.id}`}
               className="mb-1 block text-sm font-medium text-neutral-700"
             >
-              WhatsApp
+              WhatsApp *
             </label>
-            <input
+            <InputMask
+              mask="(99) 99999-9999"
               id={`whatsapp-${item.id}`}
               type="text"
               className="w-full rounded-md border border-neutral-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-climb-500"
               value={participantDetails[item.id]?.whatsapp || ''}
-              onChange={e => onChange(item.id, 'whatsapp', e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(item.id, 'whatsapp', e.target.value)}
               placeholder="(11) 99999-9999"
             />
 

--- a/src/components/cart/__tests__/CheckoutForm.test.tsx
+++ b/src/components/cart/__tests__/CheckoutForm.test.tsx
@@ -127,6 +127,7 @@ describe('CheckoutForm', () => {
       await user.type(screen.getByLabelText(/Nome Completo/), 'João Silva');
       await user.type(screen.getByLabelText(/Idade/), '25');
       await user.selectOptions(screen.getByLabelText(/Nível de Experiência/), 'beginner');
+      await user.type(screen.getByLabelText(/WhatsApp \*/), '11999999999');
 
       await user.click(
         screen.getByLabelText(
@@ -148,6 +149,7 @@ describe('CheckoutForm', () => {
       await user.type(screen.getByLabelText(/Nome Completo/), 'João Silva');
       await user.type(screen.getByLabelText(/Idade/), '25');
       await user.selectOptions(screen.getByLabelText(/Nível de Experiência/), 'beginner');
+      await user.type(screen.getByLabelText(/WhatsApp \*/), '11999999999');
 
       await user.click(
         screen.getByLabelText(
@@ -199,6 +201,7 @@ describe('CheckoutForm', () => {
       await user.type(screen.getByLabelText(/Nome Completo/), 'João Silva');
       await user.type(screen.getByLabelText(/Idade/), '25');
       await user.selectOptions(screen.getByLabelText(/Nível de Experiência/), 'beginner');
+      await user.type(screen.getByLabelText(/WhatsApp \*/), '11999999999');
 
       await user.click(
         screen.getByLabelText(
@@ -253,6 +256,7 @@ describe('CheckoutForm', () => {
       await user.type(screen.getByLabelText(/Nome Completo/), 'João Silva');
       await user.type(screen.getByLabelText(/Idade/), '25');
       await user.selectOptions(screen.getByLabelText(/Nível de Experiência/), 'beginner');
+      await user.type(screen.getByLabelText(/WhatsApp \*/), '11999999999');
 
       await user.click(
         screen.getByLabelText(
@@ -287,6 +291,7 @@ describe('CheckoutForm', () => {
       await user.type(screen.getByLabelText(/Nome Completo/), 'João Silva');
       await user.type(screen.getByLabelText(/Idade/), '25');
       await user.selectOptions(screen.getByLabelText(/Nível de Experiência/), 'beginner');
+      await user.type(screen.getByLabelText(/WhatsApp \*/), '11999999999');
 
       await user.click(
         screen.getByLabelText(
@@ -309,6 +314,7 @@ describe('CheckoutForm', () => {
       await user.type(screen.getByLabelText(/Nome Completo/), 'João Silva');
       await user.type(screen.getByLabelText(/Idade/), '25');
       await user.selectOptions(screen.getByLabelText(/Nível de Experiência/), 'beginner');
+      await user.type(screen.getByLabelText(/WhatsApp \*/), '11999999999');
 
       await user.click(
         screen.getByLabelText(
@@ -347,6 +353,8 @@ describe('CheckoutForm', () => {
 
       // Complete required fields
       await user.selectOptions(screen.getByLabelText(/Nível de Experiência/), 'beginner');
+
+      await user.type(screen.getByLabelText(/WhatsApp \*/), '11999999999');
 
       await user.click(
         screen.getByLabelText(

--- a/src/core/entities/Order.ts
+++ b/src/core/entities/Order.ts
@@ -36,6 +36,7 @@ export interface ParticipantDetails {
   age: number;
   experienceLevel: 'beginner' | 'intermediate' | 'advanced';
   healthDeclaration: boolean;
+  whatsapp?: string; // WhatsApp number
   tenis?: string; // Número do tênis (opcional)
   emergencyContact?: {
     name: string;


### PR DESCRIPTION
Added `react-input-mask` dependency and updated the WhatsApp input field in `CheckoutForm` to enforce a standard Brazilian mobile format `(99) 99999-9999`. The validation now correctly ensures that the inputted WhatsApp number contains exactly 11 digits to proceed to the next step. I've also updated the related TypeScript types and tests to support and verify the new behavior correctly.

---
*PR created automatically by Jules for task [6257929350647956314](https://jules.google.com/task/6257929350647956314) started by @govinda777*