### PR TITLE
feat: add error boundary pages for better UX on crash

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/components/ui';
+import { AlertTriangle } from 'lucide-react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('App Error:', error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full bg-white rounded-2xl shadow-xl p-8 text-center border border-gray-100">
+        <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-6">
+          <AlertTriangle className="w-8 h-8 text-red-600" />
+        </div>
+
+        <h2 className="text-2xl font-bold text-gray-900 mb-4">Ops! Algo deu errado.</h2>
+
+        <p className="text-gray-600 mb-8">
+          Encontramos um problema inesperado ao carregar a aplicação. Pode ser uma instabilidade
+          temporária.
+        </p>
+
+        <div className="space-y-4">
+          <Button onClick={() => reset()} className="w-full bg-climb-500 hover:bg-climb-600">
+            Tentar Novamente
+          </Button>
+
+          <Button variant="outline" onClick={() => (window.location.href = '/')} className="w-full">
+            Voltar para o Início
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { Inter } from 'next/font/google';
+import '../styles/globals.css';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="pt-BR">
+      <body className={`${inter.className} bg-white`}>
+        <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+          <div className="max-w-md w-full bg-white rounded-2xl shadow-xl p-8 text-center border border-gray-100">
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">Erro Crítico</h2>
+            <p className="text-gray-600 mb-8 text-sm break-words">
+              {error.message || 'Ocorreu um erro fatal ao renderizar a aplicação.'}
+            </p>
+            <button
+              onClick={() => reset()}
+              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+            >
+              Recarregar Aplicação
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
This PR introduces standard Next.js error boundaries (`error.tsx` and `global-error.tsx`) at the root level of the application. The goal is to provide a user-friendly fallback UI whenever a client-side or server-side exception occurs that would otherwise result in the default white "Application error: a client-side exception has occurred" Next.js error screen.

The user originally reported this generic error page showing up, which we suspected could be an unhandled client-side crash triggered by a third-party script or API like Privy when initialized with a dummy ID. While the underlying cause of the crash appears to have resolved itself (API instability), adding these boundaries ensures that future errors display our custom, styled error page rather than breaking the application completely, giving users a way to retry the render or navigate back to safety.

---
*PR created automatically by Jules for task [14605968940023493034](https://jules.google.com/task/14605968940023493034) started by @govinda777*